### PR TITLE
closure, k_normal: Fix for incorrect set arithmetic - closes #10

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -95,7 +95,7 @@ pub fn fv(e: &T) -> im::hashset::HashSet<id::T> {
         AppDir(_, ys) | Tuple(ys) => S::from_iter(ys.iter().cloned()),
         LetTuple(xts, y, e) => {
             S::unit(y.clone())
-                + fv(e).difference(S::from_iter(
+                + fv(e).relative_complement(S::from_iter(
                     xts.iter().map(|(x, _)| x.clone()),
                 ))
         }
@@ -208,8 +208,9 @@ pub fn g(
             Warning: A closure is necessary when variable `x` appears in e1' (e1_)!
             (thanks to nuevo-namasute and azounoman; see test/cls-bug2.ml
              */
-            let zs = fv(&e1_)
-                .difference(S::from_iter(yts.iter().map(|(y, _)| y.clone())));
+            let zs = fv(&e1_).relative_complement(S::from_iter(
+                yts.iter().map(|(y, _)| y.clone()),
+            ));
             let (known_, e1_) = if zs.is_empty() {
                 (known_, e1_)
             } else {
@@ -236,13 +237,16 @@ pub fn g(
             /* 自由変数のリスト */
             /* free variable list */
             let zs: Vec<id::T> = Vec::from_iter(
-                (fv(&e1_).difference(
+                (fv(&e1_).relative_complement(
                     S::unit(x.clone())
                         + S::from_iter(yts.iter().map(|(ref y, _)| y.clone())),
                 ))
                 .iter()
                 .cloned(),
             );
+            eprintln!("fv(e1_) = {:?}", fv(&e1_));
+            eprintln!("yts = {:?}", yts);
+            eprintln!("zs = {:?}", zs);
             /* ここで自由変数zの型を引くために引数envが必要 */
             /*
             Here `env` is necessary to look up the type of free

--- a/src/k_normal.rs
+++ b/src/k_normal.rs
@@ -79,8 +79,9 @@ pub fn fv(e: T) -> im::hashset::HashSet<id::T> {
             },
             e2,
         ) => {
-            let zs = fv(*e1)
-                .difference(S::from_iter(yts.iter().map(|(x, _)| x.clone())));
+            let zs = fv(*e1).relative_complement(S::from_iter(
+                yts.iter().map(|(x, _)| x.clone()),
+            ));
             (zs + fv(*e2)).without(&x)
         }
         App(x, ys) => S::from_iter([x].into_iter().chain(ys)),
@@ -88,8 +89,9 @@ pub fn fv(e: T) -> im::hashset::HashSet<id::T> {
         Put(x, y, z) => S::from_iter([x, y, z]),
         LetTuple(xs, y, e) => {
             S::unit(y)
-                + fv(*e)
-                    .difference(S::from_iter(xs.into_iter().map(|(x, _)| x)))
+                + fv(*e).relative_complement(S::from_iter(
+                    xs.into_iter().map(|(x, _)| x),
+                ))
         }
     }
 }

--- a/src/test/closure.rs
+++ b/src/test/closure.rs
@@ -1,0 +1,62 @@
+use crate::alpha;
+use crate::closure;
+use crate::k_normal;
+use crate::lexer;
+use crate::parser;
+use crate::typing;
+
+use std::fs;
+
+// FIXME: parameterised tests
+#[test]
+fn test_f() {
+    for entry in fs::read_dir("src/test/ml").unwrap() {
+        let path = entry.unwrap().path();
+
+        // FIXME: WIP - ignore these tests for now due to bugs in parser
+        if false {
+            let ignore_tests = [
+                "even-odd.ml",
+                "cls-bug2.ml",
+                "inprod-loop.ml",
+                "matmul-flat.ml",
+                "cls-reg-bug.ml",
+                "non-tail-if.ml",
+                "inprod-rec.ml",
+                "matmul.ml",
+            ];
+            if ignore_tests.iter().any(|t| path.ends_with(t)) {
+                continue;
+            }
+        }
+        if !path.is_dir() {
+            println!("*** {:?}", path);
+            let contents =
+                fs::read_to_string(path.clone()).unwrap_or_else(|_| {
+                    panic!("unable to read {}", path.display())
+                });
+            let res = lexer::parser::main(&contents);
+            let tokens = res.unwrap();
+            println!("{:?}", tokens);
+
+            let syn_res = parser::parser::exp(&tokens, ());
+            assert!(syn_res.is_ok());
+            let syn = syn_res.unwrap();
+            println!("{:?}", syn);
+
+            let syn_ty_res = typing::f(&syn.clone());
+            println!("{:?}", syn_ty_res);
+            assert!(syn_ty_res.is_ok());
+
+            let syn_ty = syn_ty_res.unwrap();
+            let norm = k_normal::f(&syn_ty);
+            println!("{:?}", norm);
+
+            let alpha_exp = alpha::f(&norm);
+            println!("{:?}", alpha_exp);
+
+            let closure_converted = closure::f(&alpha_exp);
+            println!("{:?}", closure_converted);
+        }
+    }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,3 +1,4 @@
+mod closure;
 #[rustfmt::skip] mod lexer;
 #[rustfmt::skip] mod parser;
 mod k_normal;


### PR DESCRIPTION
Cause was the use of `im::hashset::difference`.
`Set.diff` in Ocaml corresponds to `im::hashset::relative_complement` in `im::hashset`. `difference` is the symmetric difference.

